### PR TITLE
fix import collision error

### DIFF
--- a/zap.go
+++ b/zap.go
@@ -7,7 +7,7 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/microsoft/hcsshim"
+	"github.com/Microsoft/hcsshim"
 )
 
 func folderexists(path string) bool {


### PR DESCRIPTION
Fixes an error when using go version go1.13.6 windows/amd64

```
..\github.com\Microsoft\hcsshim\vendor\github.com\Microsoft\go-winio\hvsock.go:12:2: case-insensitive import collision: "github.com/Microsoft/hcsshim/vendor/github.com/Microsoft/go-winio/pkg/guid" and "github.com/microsoft/hcsshim/vendor/github.com/Microsoft/go-winio/pkg/guid"
..\github.com\Microsoft\hcsshim\vendor\github.com\Microsoft\go-winio\pkg\guid\guid.go:16:2: case-insensitive import collision: "github.com/Microsoft/hcsshim/vendor/golang.org/x/sys/windows" and "github.com/microsoft/hcsshim/vendor/golang.org/x/sys/windows"
```